### PR TITLE
Add support for Microsoft Edge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(root, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 requirements = [
-    'cryptography',
+    'cryptography>=2.5',
     'PyJWT',
     'requests',
 ]

--- a/webnoti/__init__.py
+++ b/webnoti/__init__.py
@@ -6,7 +6,7 @@
     It tries to be simple, concise, but still extensive.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 from .notification import send_notification, Notification
 from .utils import get_private_key

--- a/webnoti/encryption.py
+++ b/webnoti/encryption.py
@@ -5,6 +5,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 
@@ -86,9 +87,9 @@ def encrypt_data(client_encoded_public_key, client_auth_secret, data):
     :param data: An actual data to send (bytes)
     :return: A 2-tuple containing (headers, data), each in dict, bytes
     """
-    client_public_key = ec.EllipticCurvePublicNumbers\
-                          .from_encoded_point(curve, client_encoded_public_key)\
-                          .public_key(backend)
+    client_public_key = ec.EllipticCurvePublicKey.from_encoded_point(
+        curve, client_encoded_public_key
+    )
 
     # Generate salt
     salt = os.urandom(16)
@@ -96,7 +97,7 @@ def encrypt_data(client_encoded_public_key, client_auth_secret, data):
     # Generate Server Public & Private Key pair
     server_private_key = ec.generate_private_key(curve, backend)
     server_public_key = server_private_key.public_key()
-    server_public_key_bytes = server_public_key.public_numbers().encode_point()
+    server_public_key_bytes = server_public_key.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
     # Derive shared secret using ECDH
     shared_secret = server_private_key.exchange(ec.ECDH(), client_public_key)
 

--- a/webnoti/notification.py
+++ b/webnoti/notification.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from urllib import parse
 
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 import jwt
 import requests
 
@@ -82,8 +83,15 @@ class Notification(object):
             ciphertext = b''
         headers['TTL'] = str(self.TTL)
         if self.vapid_private_key is not None:
-            vapid_public_key_b64 = b64encode(self.vapid_private_key.public_key().public_numbers().encode_point())\
-                .decode('utf-8').strip('=')
+            vapid_public_key_b64 = (
+                b64encode(
+                    self.vapid_private_key.public_key().public_bytes(
+                        Encoding.X962, PublicFormat.UncompressedPoint
+                    )
+                )
+                .decode("utf-8")
+                .strip("=")
+            )
             signed_claim = sign_vapid(self.generate_claims(), self.vapid_private_key)
             headers[
                 "Authorization"

--- a/webnoti/notification.py
+++ b/webnoti/notification.py
@@ -84,12 +84,12 @@ class Notification(object):
         if self.vapid_private_key is not None:
             vapid_public_key_b64 = b64encode(self.vapid_private_key.public_key().public_numbers().encode_point())\
                 .decode('utf-8').strip('=')
-            vapid = sign_vapid(self.generate_claims(), self.vapid_private_key)
-            headers['Authorization'] = 'WebPush ' + vapid
-            if 'Crypto-Key' in headers:
-                headers['Crypto-Key'] += '; p256ecdsa=' + vapid_public_key_b64
-            else:
-                headers['Crypto-Key'] = 'p256ecdsa=' + vapid_public_key_b64
+            signed_claim = sign_vapid(self.generate_claims(), self.vapid_private_key)
+            headers[
+                "Authorization"
+            ] = "vapid t={signed_claim}, k={vapid_signing_key}".format(
+                signed_claim=signed_claim, vapid_signing_key=vapid_public_key_b64
+            )
         return requests.post(self.endpoint, headers=headers, data=ciphertext)
 
 


### PR DESCRIPTION
## Abstract
Previous versions of `python-webnoti` did not work on MS Edge. This PR addresses the issue.
## Description
In the previous versions of python-webpush, it used an outdated 'WebPush' authentication scheme to identify itself to push services.
This made Windows Push Notification Service (which Edge uses) reject our push request. Fix this by adopting 'vapid' authentication scheme.
More information can be found at: https://tools.ietf.org/html/rfc8292
### Some more contexts
The 'WebPush' scheme was outdated in `draft-02`. FCM and Autopush still supports this old scheme, but it looks like WNS only implemented newer standards.